### PR TITLE
Centralize boilerplate, improve development workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,6 +18,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
+        working-directory: server
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,27 +2,32 @@ name: Rust
 
 on:
   push:
-    branches: [ master ]
-    paths: [ 'server/*' ]
+    branches: [master]
+    paths: ["server/*"]
   pull_request:
-    branches: [ master ]
-    paths: [ 'server/*' ]
+    branches: [master]
+    paths: ["server/*"]
 
 env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
-
+  clippy_check:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Lint
-      uses: actions-rs/clippy-check@v1
-    - name: Build
-      run: cargo build --verbose
-      working-directory: server
-    - name: Run tests
-      run: cargo test --verbose
-      working-directory: server
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
+  build_and_test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build
+        run: cargo build --verbose
+        working-directory: server
+      - name: Run tests
+        run: cargo test --verbose
+        working-directory: server

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,6 @@ jobs:
       - uses: actions/checkout@v2
       - run: rustup component add clippy
       - uses: actions-rs/clippy-check@v1
-        working-directory: server
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: --all-features --manifest-path server/Cargo.toml

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -21,7 +21,7 @@ jobs:
         working-directory: server
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+          args: --all-features --manifest-path server/Cargo.toml
   build_and_test:
     runs-on: ubuntu-latest
     steps:

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "cargo",
+      "command": "build",
+      "problemMatcher": ["$rustc"],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "label": "build server",
+      "options": {
+        "cwd": "server"
+      }
+    },
+    {
+      "type": "shell",
+      "command": "systemfd",
+      "problemMatcher": ["$rustc"],
+      "label": "run development server",
+      "options": {
+        "cwd": "server",
+        "env": {
+          "RUST_LOG": "info"
+        }
+      },
+      "args": [
+        "--no-pid",
+        "-s",
+        "http::8080",
+        "--",
+        "cargo",
+        "watch",
+        "-x",
+        "run --features autoreload --features graphiql"
+      ]
+    }
+  ]
+}

--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -861,6 +861,16 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "listenfd"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)",
+ "uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1334,6 +1344,7 @@ dependencies = [
  "anyhow 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "juniper 0.14.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pretty_env_logger 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.112 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1577,6 +1588,14 @@ dependencies = [
 
 [[package]]
 name = "uuid"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cfg-if 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "uuid"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
@@ -1749,6 +1768,7 @@ dependencies = [
 "checksum libc 0.2.71 (registry+https://github.com/rust-lang/crates.io-index)" = "9457b06509d27052635f90d6466700c65095fdf75409b3fbdd903e988b886f49"
 "checksum linked-hash-map 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6d262045c5b87c0861b3f004610afd0e2c851e2908d08b6c870cbb9d5f494ecd"
 "checksum linked-hash-map 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8dd5a6d5999d9907cda8ed67bbd137d3af8085216c2ac62de5be860bd41f304a"
+"checksum listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "492158e732f2e2de81c592f0a2427e57e12cd3d59877378fe7af624b6bbe0ca1"
 "checksum lock_api 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c4da24a77a3d8a6d4862d95f72e6fdb9c09a643ecdb402d754004a557f2bec75"
 "checksum log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)" = "14b6052be84e6b71ab17edffc2eeabf5c2c3ae1fdb464aae35ac50c67a44e1f7"
 "checksum lru-cache 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
@@ -1832,6 +1852,7 @@ dependencies = [
 "checksum unicode-width 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "caaa9d531767d1ff2150b9332433f32a24622147e5ebb1f26409d5da67afd479"
 "checksum unicode-xid 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
 "checksum url 2.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "829d4a8476c35c9bf0bbce5a3b23f4106f79728039b726d292bb93bc106787cb"
+"checksum uuid 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e1436e58182935dcd9ce0add9ea0b558e8a87befe01c1a301e6020aeb0876363"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 "checksum version_check 0.9.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b5a972e5669d67ba988ce3dc826706fb0a8b01471c088cb0b6110b805cc36aed"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -12,10 +12,12 @@ actix-rt = "1"
 anyhow = "1"
 config = "0.10"
 juniper = "0.14"
+listenfd = { version = "0.3", optional = true }
 pretty_env_logger = "0.4"
 serde = "1"
 serde_json = "1"
 structopt = "0.3"
 
 [features]
+autoreload = ["listenfd"]
 graphiql = []

--- a/server/README.md
+++ b/server/README.md
@@ -1,31 +1,64 @@
 # Running the server binary
-`cargo run`'s default invocation will start a server listening on the ipv4
-loopback address (127.0.0.1), port 8080.
+
+`cargo run`'s default invocation will start a server listening on localhost,
+port 8080.
+
 ```
 cargo run
 ```
+
 By default, graphiql is not exposed, to ensure that it is not accidentally
 exposed in production. You can expose graphiql by enabling the 'graphiql'
 feature:
+
 ```
 cargo run --features graphiql
 ```
 
+Then open `http://localhost:8080/graphiql` in your browser. If you prefer
+GraphQL Playground, that's available at `http://localhost:8080/playground`.
+
+## Autoreload
+
+Autoreload can speed up the development cycle by automatically rebuilding and
+re-running the server on any source or config changes. To enable autoreload,
+you'll need to install cargo-watch and systemfd:
+
+```
+cargo install cargo-watch systemfd
+```
+
+To support autoreloading, the 'autoreload' feature must be enabled. Then you
+can use systemfd to automatically invoke `cargo run` on any filesystem
+changes, and forward http traffic from port 8080:
+
+```
+RUST_LOG=info systemfd --no-pid -s http::8080 -- cargo watch -x \
+"run --features autoreload --features graphiql"
+```
+
+This command is rather complicated, but if you use VS Code as your editor (I
+recommend the extensions Better TOML, crates, and rust-analyzer for rust
+development), the task 'run development server' makes it easy.
+
 # Configuring the server binary
 
-Configuration parameters must be defined and assigned a default value in
-conf/default.toml, so that values may be accessed via `.unwrap()`. To create a
-different configuration 'flavor', create another .toml file in the conf/
-folder containing only the overridden values, and pass it to the binary via
-the `-c` flag. (This approach allows us to safely add new configuration
-parameters to default.toml without requiring them to be added to all 'flavors'
-immediately.) For example:
+Configuration parameters must be defined, documented, and assigned a default
+value in `conf/default.toml`, so that values may be accessed via `.unwrap()`.
+To create a different configuration 'flavor', create another `.toml` file in
+the `conf/` folder containing only the overridden values, and pass it to the
+binary via the `-c` flag. (This approach allows us to safely add new
+configuration parameters to default.toml without requiring them to be added to
+all 'flavors' immediately.) For example:
+
 ```
 cargo run -- -c conf/prod.toml
 ```
+
 You can additionally override individual values at the time of command
 invocation by adding an environment variable of the form `DEF_param_name=val`.
 These are applied after any overrides provided in the provided conf file.
+
 ```
 DEF_foo=bar cargo run -- -c conf/prod.toml
 ```
@@ -33,6 +66,7 @@ DEF_foo=bar cargo run -- -c conf/prod.toml
 The one exception is logging level, which is set via the `RUST_LOG`
 environment variable. See top-level documentation for the env_logger
 crate for details. For example, to view `INFO` logs from the actix_web logger:
+
 ```
 RUST_LOG="actix_web=info" cargo run --features graphiql
 ```

--- a/server/conf/default.toml
+++ b/server/conf/default.toml
@@ -1,3 +1,12 @@
 # Every config option used in the server should be assigned a default value here
 # in order to guarantee no config values are undefined
-addr = "127.0.0.1:8080"
+
+# Address on which the server listens. By default listen only to loopback
+listen_addr = "127.0.0.1"
+
+# Port on which the server listens.
+listen_port = 8080
+
+# Name of the server, used for URL generation
+server_name = "localhost"
+


### PR DESCRIPTION
- Put all the server/endpoint setup boilerplate in main.rs to get it out of the way
- Rather than bundling everything into one AppData, use web::Data<T> for each field. This allows us to limit unnecessary synchronization across workers, and avoid the antipattern of passing around a huge struct
- Use actix-web's support for URL generation rather than passing around an address unnecessarily
- Support autoreload, to speed up development cycle