### PR TITLE
Add 'squads' (groups)

### DIFF
--- a/server/Cargo.lock
+++ b/server/Cargo.lock
@@ -722,6 +722,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "diesel-derive-enum"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "proc-macro2 1.0.18 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 1.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 1.0.31 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "diesel_derives"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1759,6 +1770,7 @@ dependencies = [
  "async-graphql-actix-web 1.16.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "config 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "diesel 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "diesel-derive-enum 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "listenfd 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2265,6 +2277,7 @@ dependencies = [
 "checksum crossbeam-utils 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 "checksum derive_more 0.99.7 (registry+https://github.com/rust-lang/crates.io-index)" = "2127768764f1556535c01b5326ef94bd60ff08dcfbdc544d53e69ed155610f5d"
 "checksum diesel 1.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "3e2de9deab977a153492a1468d1b1c0662c1cf39e5ea87d0c060ecd59ef18d8c"
+"checksum diesel-derive-enum 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "703e71c268ea2d8da9c0ab0b40d8b217179ee622209c170875d24443193a0dfb"
 "checksum diesel_derives 1.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "45f5098f628d02a7a0f68ddba586fb61e80edec3bdc1be3b921f4ceec60858d3"
 "checksum digest 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f3d0c8c8752312f9713efd397ff63acb9f85585afbf179282e720e7704954dd5"
 "checksum dotenv 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -14,6 +14,7 @@ async-graphql = "1.16.2"
 async-graphql-actix-web = "1.16.1"
 config = "0.10"
 diesel = { version = "1.4.5", features = [ "postgres", "r2d2", "uuidv07" ]}
+diesel-derive-enum = { version = "1", features = [ "postgres" ]}
 dotenv = "0.15"
 listenfd = { version = "0.3", optional = true }
 log = "0.4"

--- a/server/migrations/2020-06-27-231312_create_user/down.sql
+++ b/server/migrations/2020-06-27-231312_create_user/down.sql
@@ -1,3 +1,4 @@
 -- This file should undo anything in `up.sql`
 DROP TABLE person;
 DROP TABLE node;
+DROP TYPE node_type;

--- a/server/migrations/2020-06-27-231312_create_user/up.sql
+++ b/server/migrations/2020-06-27-231312_create_user/up.sql
@@ -11,3 +11,6 @@ CREATE TABLE person (
     first_name VARCHAR(50) NOT NULL,
     last_name VARCHAR(50) NOT NULL
 );
+CREATE INDEX ON node ( id, uid );
+CREATE INDEX ON node ( uid, id );
+CREATE INDEX ON person ( node_id );

--- a/server/migrations/2020-06-27-231312_create_user/up.sql
+++ b/server/migrations/2020-06-27-231312_create_user/up.sql
@@ -1,7 +1,9 @@
 -- Your SQL goes here
+CREATE TYPE node_type AS ENUM ('person');
 CREATE TABLE node (
     id SERIAL PRIMARY KEY,
-    uid UUID NOT NULL UNIQUE
+    uid UUID NOT NULL UNIQUE,
+    node_type node_type NOT NULL
 );
 CREATE TABLE person (
     id SERIAL PRIMARY KEY,

--- a/server/migrations/2020-08-01-181305_create_squad/down.sql
+++ b/server/migrations/2020-08-01-181305_create_squad/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+DROP TABLE person_squad_connection;
+DROP TABLE squad;

--- a/server/migrations/2020-08-01-181305_create_squad/up.sql
+++ b/server/migrations/2020-08-01-181305_create_squad/up.sql
@@ -12,3 +12,4 @@ CREATE TABLE person_squad_connection (
 CREATE INDEX ON squad ( node_id );
 CREATE INDEX ON person_squad_connection ( person_id, id, squad_id );
 CREATE INDEX ON person_squad_connection ( squad_id, id, person_id );
+ALTER TYPE node_type ADD VALUE IF NOT EXISTS 'squad';

--- a/server/migrations/2020-08-01-181305_create_squad/up.sql
+++ b/server/migrations/2020-08-01-181305_create_squad/up.sql
@@ -1,0 +1,14 @@
+-- Your SQL goes here
+CREATE TABLE squad (
+    id SERIAL PRIMARY KEY,
+    node_id INTEGER NOT NULL REFERENCES node(id) ON DELETE CASCADE,
+    display_name VARCHAR(50) NOT NULL
+);
+CREATE TABLE person_squad_connection (
+    id SERIAL PRIMARY KEY,
+    person_id INTEGER NOT NULL REFERENCES person(id) ON DELETE CASCADE,
+    squad_id INTEGER NOT NULL REFERENCES squad(id) ON DELETE CASCADE
+);
+CREATE INDEX ON squad ( node_id );
+CREATE INDEX ON person_squad_connection ( person_id, id, squad_id );
+CREATE INDEX ON person_squad_connection ( squad_id, id, person_id );

--- a/server/src/db/models.rs
+++ b/server/src/db/models.rs
@@ -11,10 +11,10 @@ pub struct Node {
 #[derive(Queryable, Identifiable)]
 #[table_name = "person"]
 pub struct PersonDetail {
-    pub node_id: i32,
     pub id: i32,
-    pub email: String,
+    pub node_id: i32,
     pub display_name: String,
+    pub email: String,
     pub first_name: String,
     pub last_name: String,
 }
@@ -28,8 +28,8 @@ pub struct Person {
 #[derive(Queryable, Identifiable)]
 #[table_name = "squad"]
 pub struct SquadDetail {
-    pub node_id: i32,
     pub id: i32,
+    pub node_id: i32,
     pub display_name: String,
 }
 
@@ -47,6 +47,13 @@ pub struct NewPerson<'a> {
     pub display_name: &'a str,
     pub first_name: &'a str,
     pub last_name: &'a str,
+}
+
+#[derive(Insertable)]
+#[table_name = "squad"]
+pub struct NewSquad<'a> {
+    pub node_id: i32,
+    pub display_name: &'a str,
 }
 
 #[derive(Identifiable, Queryable)]

--- a/server/src/db/models.rs
+++ b/server/src/db/models.rs
@@ -1,11 +1,26 @@
 use super::schema::{node, person, person_squad_connection, squad};
+use diesel_derive_enum::DbEnum;
 use uuid::Uuid;
+
+#[derive(Debug, DbEnum)]
+pub enum NodeType {
+    Person,
+    Squad,
+}
 
 #[derive(Queryable, Identifiable)]
 #[table_name = "node"]
 pub struct Node {
     pub id: i32,
     pub uid: Uuid,
+    pub node_type: NodeType,
+}
+
+#[derive(Insertable)]
+#[table_name = "node"]
+pub struct NewNode {
+    pub uid: Uuid,
+    pub node_type: NodeType,
 }
 
 #[derive(Queryable, Identifiable)]

--- a/server/src/db/models.rs
+++ b/server/src/db/models.rs
@@ -1,4 +1,4 @@
-use super::schema::{node, person};
+use super::schema::{node, person, person_squad_connection, squad};
 use uuid::Uuid;
 
 #[derive(Queryable, Identifiable)]
@@ -25,6 +25,20 @@ pub struct Person {
     pub detail: PersonDetail,
 }
 
+#[derive(Queryable, Identifiable)]
+#[table_name = "squad"]
+pub struct SquadDetail {
+    pub node_id: i32,
+    pub id: i32,
+    pub display_name: String,
+}
+
+#[derive(Queryable)]
+pub struct Squad {
+    pub node: Node,
+    pub detail: SquadDetail,
+}
+
 #[derive(Insertable)]
 #[table_name = "person"]
 pub struct NewPerson<'a> {
@@ -33,4 +47,19 @@ pub struct NewPerson<'a> {
     pub display_name: &'a str,
     pub first_name: &'a str,
     pub last_name: &'a str,
+}
+
+#[derive(Identifiable, Queryable)]
+#[table_name = "person_squad_connection"]
+pub struct PersonSquadConnection {
+    pub id: i32,
+    pub person_id: i32,
+    pub squad_id: i32,
+}
+
+#[derive(Insertable)]
+#[table_name = "person_squad_connection"]
+pub struct NewPersonSquadConnection {
+    pub person_id: i32,
+    pub squad_id: i32,
 }

--- a/server/src/db/schema.rs
+++ b/server/src/db/schema.rs
@@ -2,6 +2,7 @@ table! {
     node (id) {
         id -> Int4,
         uid -> Uuid,
+        node_type -> crate::db::models::NodeTypeMapping,
     }
 }
 
@@ -37,9 +38,4 @@ joinable!(person_squad_connection -> person (person_id));
 joinable!(person_squad_connection -> squad (squad_id));
 joinable!(squad -> node (node_id));
 
-allow_tables_to_appear_in_same_query!(
-    node,
-    person,
-    person_squad_connection,
-    squad,
-);
+allow_tables_to_appear_in_same_query!(node, person, person_squad_connection, squad,);

--- a/server/src/db/schema.rs
+++ b/server/src/db/schema.rs
@@ -16,9 +16,30 @@ table! {
     }
 }
 
+table! {
+    person_squad_connection (id) {
+        id -> Int4,
+        person_id -> Int4,
+        squad_id -> Int4,
+    }
+}
+
+table! {
+    squad (id) {
+        id -> Int4,
+        node_id -> Int4,
+        display_name -> Varchar,
+    }
+}
+
 joinable!(person -> node (node_id));
+joinable!(person_squad_connection -> person (person_id));
+joinable!(person_squad_connection -> squad (squad_id));
+joinable!(squad -> node (node_id));
 
 allow_tables_to_appear_in_same_query!(
     node,
     person,
+    person_squad_connection,
+    squad,
 );


### PR DESCRIPTION
Why are they called squads? Because 'group' is a reserved keyword in sql, and because why not? Squads are the second node type added, so this PR establishes how we handle resolving generic Nodes.

**Highlights**:
- The node table gets a node_type enum so that the node resolver knows which table to join against (this requires the node resolution to be a two-query transaction).
- I discovered while implementing this that getting a Model struct from the output of a Diesel join query requires that the fields are in the same order - so I modified the existing structs accordingly.
- There is a many-to-many relationship between people and squads, which is modeled using the person_squad_connection table.
- Resolving the squads that a person is a member of and the people that are members of a squad requires the GraphQL objects to have the internal database ID - since all of the fields of the DB model are used by the GraphQL resolver, I refactored the GraphQL objects to be wrappers around the DB models. This also makes certain operations (e.g. UUID -> String conversion) lazy so that they are only performed if the relevant fields are accessed.
- Adopting the relay server specification for Mutations and Connections (without paging for now). More details on that below.
- There are probably opportunities to factor out repeated logic used to introduce/query Squads and People, but I need to read up on Rust generics before trying that - that'll be in a future PR.

**Relay GraphQL Server Spec details**:
- Mutations have a single argument named `input` and return a single 'payload' object. By convention, the mutation's name is a verb, the input is named '{MutationName}Input', and the output is named '{MutationName}Payload'.
- A connection between nodes is implemented by declaring a node field that returns a 'Connection Type'
- A Connection Type must contain a list of edges and a PageInfo object
- An Edge Type must contain a node and a cursor, where the latter is an opaque string used for pagination
- A connection field must accept forward pagination arguments, backward pagination arguments, or both.
  - Forward pagination arguments are 'first' (non-neg integer) and 'after' (opaque cursor)
  - Backward pagination arguments are 'last' (non-neg integer) and 'before' (opaque cursor)
  - For ordering to be consistent, that 'cursor' must specify the _ordering_ of edges in addition to identifying a specific node
- The PageInfo object must contain fields hasPreviousPage and hasNextPage as well as startCursor and endCursor.